### PR TITLE
Add badges for the image layers and pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # mysqlclient
+[![](https://images.microbadger.com/badges/image/tnir/mysqlclient.svg)](https://microbadger.com/images/tnir/mysqlclient "image badge powered by microbadger.com")
+
+powered by [![PyPI version](https://badge.fury.io/py/mysqlclient.svg)](https://badge.fury.io/py/mysqlclient)
+
 the mysqlclient Docker image (based on python:alpine)


### PR DESCRIPTION
Thanks to Liz, Anne & Ross at MicroBadger.com:

> We saw your image on Docker Hub at tnir/mysqlclient, and we thought you might like this badge for your GitHub page showing the image contents.
> 
> The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the contents of each layer.
> 
> If you’d like to use our badge here’s the markdown - you can simply paste this into your GitHub readme file. As you're using an automated build it will also show up in your Docker Hub description.